### PR TITLE
Removing deprecated "applications"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
-    "name": "Copy page title and url",
-    "short_name": "Copy title and url",
-    "description": "Add a context menu item to copy page title (or selected text) and url to clipboard.",
+    "name": "Copy page title and URL",
+    "short_name": "Copy title and URL",
+    "description": "Add a context menu item to copy page title (or selected text) and URL to clipboard.",
     "version": "1.3",
     "homepage_url": "https://github.com/marekjedlinski/webext-copy-title-url",
     "author": "Marek Jedliński",
@@ -27,12 +27,5 @@
         "activeTab",
         "contextMenus",
         "clipboardWrite"
-    ],
-
-    "applications": {
-      "gecko": {
-        "id": "copy_title_and_url@tranglos.com",
-        "strict_min_version": "57.0"
-      }
-    }
+    ]
 }


### PR DESCRIPTION
Removing `applications`. It's unsupported on Google Chrome and is no longer required by Firefox > 48.

From [docs]([Documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/WebExtensions_and_the_Add-on_ID#When_do_you_need_an_Add-on_ID)):

> Note that the ability to develop and debug WebExtensions that don't include an ID is new in Firefox 48. If you need to use an earlier version of Firefox, then you must use the applications key to set an ID explicitly.

Removing `applications` also lets Chrome _and_ Firefox users install the extension from the same `manifest.json`.